### PR TITLE
Upgrade to latest CGAL

### DIFF
--- a/M1.patch
+++ b/M1.patch
@@ -14,7 +14,7 @@ index 68f679de00..8d7173d9fc 100644
 -export BOOST_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$boost_version"
 -export CGAL_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$cgal_version"
 +export BOOST_ARCH_PATH=$(brew --prefix boost)
-+export CGAL_ARCH_PATH=$(brew --prefix cgal@4)
++export CGAL_ARCH_PATH=$(brew --prefix cgal)
  
  # export GMP_ARCH_PATH=...
  # export MPFR_ARCH_PATH=...

--- a/M1.patch
+++ b/M1.patch
@@ -2,7 +2,7 @@ diff --git a/etc/config.sh/CGAL b/etc/config.sh/CGAL
 index 68f679de00..8d7173d9fc 100644
 --- a/etc/config.sh/CGAL
 +++ b/etc/config.sh/CGAL
-@@ -43,11 +43,11 @@
+@@ -43,14 +43,14 @@
  #------------------------------------------------------------------------------
  # USER EDITABLE PART: Changes made here may be lost with the next upgrade
  
@@ -16,8 +16,13 @@ index 68f679de00..8d7173d9fc 100644
 +export BOOST_ARCH_PATH=$(brew --prefix boost)
 +export CGAL_ARCH_PATH=$(brew --prefix cgal)
  
- # export GMP_ARCH_PATH=...
- # export MPFR_ARCH_PATH=...
+-# export GMP_ARCH_PATH=...
+-# export MPFR_ARCH_PATH=...
++export GMP_ARCH_PATH=$(brew --prefix gmp)
++export MPFR_ARCH_PATH=$(brew --prefix mpfr)
+ 
+ # END OF (NORMAL) USER EDITABLE PART
+ #------------------------------------------------------------------------------
 diff --git a/etc/config.sh/FFTW b/etc/config.sh/FFTW
 index 6d26f9d970..d63f0feacb 100644
 --- a/etc/config.sh/FFTW

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ cd ~/OpenFOAM
 
 2. Install these components from homebrew
 ```
-brew install cmake open-mpi libomp adios2 boost fftw kahip metis petsc hypre
+brew install cmake open-mpi libomp adios2 boost cgal fftw kahip metis petsc hypre
 ```
 
-3. Install legacy `Scotch` and `CGAL` (Thanks to @gerlero for creating this [tap](https://github.com/gerlero/homebrew-openfoam/tree/main/Formula))
+3. Install legacy `Scotch` (Thanks to @gerlero for creating this [tap](https://github.com/gerlero/homebrew-openfoam/tree/main/Formula))
 ```
 brew tap gerlero/openfoam
-brew install scotch-no-pthread cgal@4
+brew install scotch-no-pthread
 ```
 
 4. Clone the OpenFOAM source code into this volume


### PR DESCRIPTION
Just in case, as of v2306, latest CGAL 5.x works without any patching. If you're willing to take this change, then I'll deprecate the `cgal@4` formula. Feel free to close otherwise.